### PR TITLE
CI: Slack alert on k6 gRPC test failure (DATA-1901)

### DIFF
--- a/.github/workflows/k6-tests.yml
+++ b/.github/workflows/k6-tests.yml
@@ -67,11 +67,30 @@ jobs:
 
       - name: Check test results
         if: always()
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
         run: |
-          failed=false
-          if [ "${{ steps.test_ghost_match_status.outcome }}" = "failure" ]; then failed=true; fi
-          if [ "${{ steps.test_ghost_match_info.outcome }}" = "failure" ]; then failed=true; fi
-          if [ "$failed" = "true" ]; then
-            echo "One or more k6 tests failed"
-            exit 1
+          FAILED=""
+          add() { [ "$2" = "failure" ] && FAILED="${FAILED:+$FAILED, }$1" || true; }
+          add ghost_match_status "${{ steps.test_ghost_match_status.outcome }}"
+          add ghost_match_info   "${{ steps.test_ghost_match_info.outcome }}"
+
+          if [ -z "$FAILED" ]; then
+            echo "All k6 tests passed"
+            exit 0
           fi
+          echo "::error::Failed k6 suites: $FAILED"
+
+          # Notify Slack on failure (no-op if SLACK_WEBHOOK_URL is unset).
+          if [ -n "$SLACK_WEBHOOK_URL" ]; then
+            RUN_URL="${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
+            # Prefer python3 for correct JSON escaping; fall back to a manual
+            # payload (content here is controlled — static suite names + URL).
+            if command -v python3 >/dev/null 2>&1; then
+              PAYLOAD=$(FAILED="$FAILED" RUN_URL="$RUN_URL" python3 -c 'import json, os; print(json.dumps({"text": ":rotating_light: ghostschema k6 gRPC tests FAILED\nSuites: {}\nRun: {}".format(os.environ["FAILED"], os.environ["RUN_URL"])}))')
+            else
+              PAYLOAD="{\"text\":\":rotating_light: ghostschema k6 gRPC tests FAILED\nSuites: ${FAILED}\nRun: ${RUN_URL}\"}"
+            fi
+            curl -fsS -X POST "$SLACK_WEBHOOK_URL" -H 'Content-Type: application/json' -d "$PAYLOAD"
+          fi
+          exit 1


### PR DESCRIPTION
Adds a Slack failure-notification step to the scheduled k6 gRPC workflow (DATA-1901 AC #5 — "where do failures surface").

- Fires only when one or more suites fail; reports which suites + a link to the run.
- Gated on a new `SLACK_WEBHOOK_URL` repo secret — **no-op until that secret is set**, so this is safe to merge ahead of the runner/secret provisioning.
- Builds the payload with `python3 json.dumps` (safe escaping) and falls back to a manual JSON string if python3 isn't on the runner (content is controlled — static suite names + run URL).
- Mirrors the Slack step already in `mimir-qa-utils/.github/workflows/mimir-smoke-tests.yml` for consistency.

No behavior change to the tests themselves; the step still `exit 1`s on failure exactly as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)